### PR TITLE
Add login endpoint using ytmusicapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # cloud-run-dj-backend
+
+A small FastAPI application that converts a list of YouTube tracks from a CSV file into MP3 downloads.
+
+## Running
+
+```bash
+uvicorn main:app --host 0.0.0.0 --port 8080
+```
+
+## Endpoints
+
+### `GET /login`
+Starts an authentication flow using `ytmusicapi` and stores the resulting cookie file in `/tmp/yt_auth.json`.
+
+### `POST /download`
+Upload a CSV file containing `artist` and `title` columns. The server downloads the songs and returns a ZIP archive of MP3 files.

--- a/main.py
+++ b/main.py
@@ -2,12 +2,22 @@ from fastapi import FastAPI, UploadFile, File
 from fastapi.responses import FileResponse
 import os
 import csv
+import tempfile
 import yt_dlp
+from ytmusicapi import setup
 import zipfile
 import uuid
 import shutil
 
 app = FastAPI()
+
+
+@app.get("/login")
+async def login():
+    """Trigger OAuth login and save cookies to /tmp."""
+    auth_path = os.path.join(tempfile.gettempdir(), "yt_auth.json")
+    setup(filepath=auth_path)
+    return {"cookies_saved": auth_path}
 
 @app.post("/download")
 async def download_csv(file: UploadFile = File(...)):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn[standard]
 yt-dlp
+ytmusicapi


### PR DESCRIPTION
## Summary
- add /login endpoint that uses ytmusicapi to store cookies
- document endpoint usage in README
- install ytmusicapi in requirements

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684196a8bcc88328b80a0b553476ee7a